### PR TITLE
Added missing closing parenthesis in flymake-vala-load definition

### DIFF
--- a/flymake-vala.el
+++ b/flymake-vala.el
@@ -58,8 +58,7 @@
   (flymake-easy-load 'flymake-vala-command
                      flymake-vala-err-line-patterns
                      'tempdir
-                     "vala")
- 
+                     "vala"))
 
 (provide 'flymake-vala)
 ;;; flymake-vala.el ends here


### PR DESCRIPTION
This was causing an "End of file during parsing" error on load.
